### PR TITLE
 Using event path instead of resource for routing

### DIFF
--- a/lib/request/request.ts
+++ b/lib/request/request.ts
@@ -23,8 +23,8 @@ export class Request implements IRequest {
         }
     }
 
-    getResource(): string {
-        return this.event.resource;
+    getPath(): string {
+        return this.event.path;
     }
 
     getRequestMethod(): HttpMethods {

--- a/lib/routing/router.ts
+++ b/lib/routing/router.ts
@@ -12,7 +12,7 @@ export class Router<M extends Middleware, C extends Controller, R extends Route<
 
   private middleware: GenericConstructor<M>[] = [];
   private subjectRoute: R; 
-  private requestRoute: string;
+  private requestPath: string;
   private requestMethod: HttpMethods;
   private pathParams: {};
 
@@ -22,7 +22,7 @@ export class Router<M extends Middleware, C extends Controller, R extends Route<
   ) { }
 
   public route(routes: R[]): void {
-    this.requestRoute = this.request.getResource()
+    this.requestPath = this.request.getPath()
     this.requestMethod = this.request.getRequestMethod();
 
     try {
@@ -49,7 +49,7 @@ export class Router<M extends Middleware, C extends Controller, R extends Route<
     if (route.method !== this.requestMethod) {
       return false;
     }
-    let params = route.url.match(this.requestRoute);
+    let params = route.url.match(this.requestPath);
     if (params) {
       this.pathParams = params;
       return true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mindless-framework",
-    "version": "1.0.0-alpha.4",
+    "version": "1.0.0-alpha.5",
     "description": "",
     "main": "dist/index.js",
     "type": "index.ts",

--- a/tests/request/request.test.ts
+++ b/tests/request/request.test.ts
@@ -26,7 +26,7 @@ describe('Test request constructor', () => {
 
     test('empty event', () => {
         let request = new Request(localEvent);
-        expect(request.getResource()).toBe("");
+        expect(request.getPath()).toBe("");
         expect(request.getRequestMethod()).toBe(HttpMethods.GET);
     });
 

--- a/tests/routing/router.test.ts
+++ b/tests/routing/router.test.ts
@@ -16,14 +16,14 @@ class TestController extends Controller {
     }
     // Note: Request parameter 
     testWithRequestParam(request: Request) {
-        return new Response(200, { resource: request.getResource() });
+        return new Response(200, { resource: request.getPath() });
     }
     testWithPathParam(val: string): Response {
         return new Response(200, { val: val });
     }
     testWithRequestAndPathParam(request: Request, val: string) {
         const res = {
-            resource: request.getResource(),
+            resource: request.getPath(),
             val: val
         };
         return new Response(200, res);
@@ -45,7 +45,7 @@ describe('Test router route method', () => {
         }
     ];
 
-    requestMock.setup(c => c.getResource()).returns(() => '/test');
+    requestMock.setup(c => c.getPath()).returns(() => '/test');
     requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.GET);
 
     test('Throws error when route group undefined', () => {
@@ -69,7 +69,7 @@ describe('Test router dispatchController method', () => {
         }
     ];
 
-    requestMock.setup(c => c.getResource()).returns(() => '/test');
+    requestMock.setup(c => c.getPath()).returns(() => '/test');
     requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.POST);
     let router = new Router<Middleware, Controller, Route<Middleware, Controller>>(requestMock.object, containerMock.object);
     router.route(routes);
@@ -135,7 +135,7 @@ describe('Test router dispactControlelr with path parameters', () => {
         let requestMock = TypeMoq.Mock.ofType<Request>();
         let containerMock = TypeMoq.Mock.ofType<Container>();
 
-        requestMock.setup(c => c.getResource()).returns(() => '/test1/' + valParam);
+        requestMock.setup(c => c.getPath()).returns(() => '/test1/' + valParam);
         requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.POST);
 
         let router = new Router<Middleware, Controller, Route<Middleware, Controller>>(requestMock.object, containerMock.object);
@@ -155,7 +155,7 @@ describe('Test router dispactControlelr with path parameters', () => {
         let requestMock = TypeMoq.Mock.ofType<Request>();
         let containerMock = TypeMoq.Mock.ofType<Container>();
 
-        requestMock.setup(c => c.getResource()).returns(() => resource);
+        requestMock.setup(c => c.getPath()).returns(() => resource);
         requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.POST);
 
         let router = new Router<Middleware, Controller, Route<Middleware, Controller>>(requestMock.object, containerMock.object);
@@ -175,7 +175,7 @@ describe('Test router dispactControlelr with path parameters', () => {
         let requestMock = TypeMoq.Mock.ofType<Request>();
         let containerMock = TypeMoq.Mock.ofType<Container>();
 
-        requestMock.setup(c => c.getResource()).returns(() => resource);
+        requestMock.setup(c => c.getPath()).returns(() => resource);
         requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.POST);
 
         let router = new Router<Middleware, Controller, Route<Middleware, Controller>>(requestMock.object, containerMock.object);
@@ -194,7 +194,7 @@ describe('Test router dispactControlelr with path parameters', () => {
         let requestMock = TypeMoq.Mock.ofType<Request>();
         let containerMock = TypeMoq.Mock.ofType<Container>();
 
-        requestMock.setup(c => c.getResource()).returns(() => '/test1');
+        requestMock.setup(c => c.getPath()).returns(() => '/test1');
         requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.POST);
 
         let router = new Router<Middleware, Controller, Route<Middleware, Controller>>(requestMock.object, containerMock.object);


### PR DESCRIPTION
There was an issue with proxy routes where it was impossible to match the route because of how the `resource` attribute works with API GW. For example, take the following configuration:
``` yml
  query:
    handler: src/query-service/handler.start
    events:
      - http:
          path: query/{proxy+}
          method: ANY
```
When I have a route defined as the following:
```js
    {
        url: new RouteUrl('/query/simple'),
        method: HttpMethods.GET,
        controller: SimpleQueryController,
        middleware: [],
        function: "create"
    }
```
It should be able to match. The issue that was occurring is that the `event.resource` string would equal `/query/{proxy+}` where what we really want is `/query/simple` which we can get with `event.path`