### PR TITLE
Added method onto response to transform into AWS lambda response

### DIFF
--- a/lib/response.ts
+++ b/lib/response.ts
@@ -1,14 +1,28 @@
+export interface AWSLambdaIntegrationResponse {
+  statusCode: number;
+  body: string;
+  headers: { [key: string]: string };
+}
+
 export class Response {
 
-    /**
-     * 
-     * @param statusCode 
-     * @param headers 
-     * @param body 
-     */
-    public constructor(
-      public statusCode: number = 200,
-      public body: {[key: string]: any}  = {},
-      public headers: {[key: string]: string} = {}
-    ) { }
+  /**
+   * 
+   * @param statusCode 
+   * @param headers 
+   * @param body 
+   */
+  public constructor(
+    public statusCode: number = 200,
+    public body: { [key: string]: any } = {},
+    public headers: { [key: string]: string } = {}
+  ) { }
+
+  public toAWSLambdaIntegrationResponse(): AWSLambdaIntegrationResponse {
+    return {
+      statusCode: this.statusCode,
+      body: JSON.stringify(this.body),
+      headers: this.headers
+    }
   }
+}


### PR DESCRIPTION
Resolves #34 

Users will now be able to something similar to the following in their handler for Lambda functions:
```js
  let res : Response = await router.dispatchController();

  callback(null, res.toAWSLambdaIntegrationResponse());
```
All this does is turn the body object into a string. I'm open ripping this out into an extension at some point, but for now this is needed if someone is using lambda