### PR TITLE
Param injection updates

### DIFF
--- a/lib/request/request.ts
+++ b/lib/request/request.ts
@@ -31,7 +31,16 @@ export class Request implements IRequest {
         return HttpMethods[this.event.httpMethod.toUpperCase()];
     }
 
-    get(key: string, failOnNotFound: boolean = true): any {
+    getOrFail(key: string): any {
+        const value = this.get(key);
+        if (value) {
+            return value;
+        }
+
+        throw Error("Invalid key: '" + key + "' , key not found in pathParameters, queryStringParameters, or Body parameters."); 
+    }
+
+    get(key: string): any {
 
         if ('undefined' !== typeof this.event.pathParameters[key]) {
             return this.event.pathParameters[key];
@@ -43,9 +52,6 @@ export class Request implements IRequest {
             return this._body[key];
         }
 
-        if (failOnNotFound) {
-            throw Error("Invalid key: '" + key + "' , key not found in pathParameters, queryStringParameters, or Body parameters.");
-        }
         return undefined;
     }
 

--- a/tests/request/request.test.ts
+++ b/tests/request/request.test.ts
@@ -55,7 +55,8 @@ describe('Test request constructor', () => {
         defaultEvent.headers = null;
 
         let request = new Request(defaultEvent);
-        expect(() => { request.get('abc') }).toThrow(/key not found/);
+        expect(() => { request.getOrFail('abc') }).toThrow(/key not found/);
+        expect(request.get('abc')).toBe(undefined);
     });
 });
 
@@ -102,7 +103,7 @@ describe('Test request get method ', () => {
 
         let request = new Request(defaultEvent);
 
-        expect(() => { request.get('abc') }).toThrow(/key not found/);
+        expect(() => { request.getOrFail('abc') }).toThrow(/key not found/);
     });
 
     test('optional key not found returns undefined', () => {
@@ -113,7 +114,7 @@ describe('Test request get method ', () => {
 
         let request = new Request(defaultEvent);
 
-        let retrievedValue = request.get('abc', false);
+        let retrievedValue = request.get('abc');
 
         expect(retrievedValue).toBe(undefined);
     });

--- a/tests/routing/router.test.ts
+++ b/tests/routing/router.test.ts
@@ -219,4 +219,8 @@ describe('Test router dispactControlelr with path parameters', () => {
         });
         requestMock.verifyAll();
     });
+
+    test('query params are injected', () => {
+        expect(true).toBeTruthy();
+    });
 });

--- a/tests/routing/router.test.ts
+++ b/tests/routing/router.test.ts
@@ -98,40 +98,22 @@ describe('Test router dispatchController method', () => {
 
 describe('Test router dispactControlelr with path parameters', () => {
 
-    let routes: MindlessRoute[] = [
-        {
-            url: new RouteUrl('/test1'),
-            method: HttpMethods.POST,
-            controller: TestController,
-            middleware: [],
-            function: "testWithPathParam"
-        },
-        {
-            url: new RouteUrl('/test1/:val'),
-            method: HttpMethods.POST,
-            controller: TestController,
-            middleware: [],
-            function: "testWithPathParam"
-        },
-        {
-            url: new RouteUrl('/test2/:val'),
-            method: HttpMethods.POST,
-            controller: TestController,
-            middleware: [],
-            function: "testWithRequestParam"
-        },
-        {
-            url: new RouteUrl('/test3/:val'),
-            method: HttpMethods.POST,
-            controller: TestController,
-            middleware: [],
-            function: "testWithRequestAndPathParam"
-        },
-    ];
 
-    const valParam = 'abc';
 
     test('path parameter get injected', async () => {
+
+        const routes: MindlessRoute[] = [
+            {
+                url: new RouteUrl('/test1/:val'),
+                method: HttpMethods.POST,
+                controller: TestController,
+                middleware: [],
+                function: "testWithPathParam"
+            }
+        ];
+
+        const valParam = 'abc';
+
         let requestMock = TypeMoq.Mock.ofType<Request>();
         let containerMock = TypeMoq.Mock.ofType<Container>();
 
@@ -153,6 +135,17 @@ describe('Test router dispactControlelr with path parameters', () => {
     });
 
     test('request object get injected', async () => {
+        let routes: MindlessRoute[] = [
+            {
+                url: new RouteUrl('/test2/:val'),
+                method: HttpMethods.POST,
+                controller: TestController,
+                middleware: [],
+                function: "testWithRequestParam"
+            }
+        ];
+
+        const valParam = 'abc';
         const resource = '/test2/' + valParam;
 
         let requestMock = TypeMoq.Mock.ofType<Request>();
@@ -173,7 +166,16 @@ describe('Test router dispactControlelr with path parameters', () => {
     });
 
     test('request object and path param get injected', async () => {
-        const resource = '/test3/' + valParam;
+        let routes: MindlessRoute[] = [
+            {
+                url: new RouteUrl('/test3/:val'),
+                method: HttpMethods.POST,
+                controller: TestController,
+                middleware: [],
+                function: "testWithRequestAndPathParam"
+            },
+        ];
+        const valParam = 'abc'; const resource = '/test3/' + valParam;
 
         let requestMock = TypeMoq.Mock.ofType<Request>();
         let containerMock = TypeMoq.Mock.ofType<Container>();
@@ -197,12 +199,22 @@ describe('Test router dispactControlelr with path parameters', () => {
     });
 
     test('throw error when cant find argument to inject into function', async () => {
+        let routes: MindlessRoute[] = [
+            {
+                url: new RouteUrl('/test1'),
+                method: HttpMethods.POST,
+                controller: TestController,
+                middleware: [],
+                function: "testWithPathParam"
+            },
+        ];
+        const valParam = 'abc';
         let requestMock = TypeMoq.Mock.ofType<Request>();
         let containerMock = TypeMoq.Mock.ofType<Container>();
 
         requestMock.setup(c => c.getPath()).returns(() => '/test1');
         requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.POST);
-        requestMock.setup(r => r.getOrFail('val')).returns(() => {throw Error()}).verifiable(TypeMoq.Times.once());
+        requestMock.setup(r => r.getOrFail('val')).returns(() => { throw Error() }).verifiable(TypeMoq.Times.once());
         requestMock.setup(r => r.add('val', 'abc')).verifiable(TypeMoq.Times.never());
 
         let router = new Router<Middleware, Controller, Route<Middleware, Controller>>(requestMock.object, containerMock.object);
@@ -220,7 +232,35 @@ describe('Test router dispactControlelr with path parameters', () => {
         requestMock.verifyAll();
     });
 
-    test('query params are injected', () => {
-        expect(true).toBeTruthy();
+    test('query params are injected', async () => {
+        let routes: MindlessRoute[] = [
+            {
+                url: new RouteUrl('/test1?val=:val'),
+                method: HttpMethods.POST,
+                controller: TestController,
+                middleware: [],
+                function: "testWithPathParam"
+            },
+        ];
+        const valParam = 'abc';
+        let requestMock = TypeMoq.Mock.ofType<Request>();
+        let containerMock = TypeMoq.Mock.ofType<Container>();
+
+        requestMock.setup(c => c.getPath()).returns(() => '/test1?val=' + valParam);
+        requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.POST);
+        requestMock.setup(r => r.getOrFail('val')).returns(() => valParam ).verifiable(TypeMoq.Times.once());
+        requestMock.setup(r => r.add('val', 'abc')).verifiable(TypeMoq.Times.once());
+
+        let router = new Router<Middleware, Controller, Route<Middleware, Controller>>(requestMock.object, containerMock.object);
+        router.route(routes);
+
+        containerMock.setup(c => c.resolve(TestController)).returns(() => new TestController());
+
+        let response = await router.dispatchController();
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body.val).toBe(valParam);
+
+        requestMock.verifyAll();
     });
 });

--- a/tests/routing/router.test.ts
+++ b/tests/routing/router.test.ts
@@ -135,8 +135,10 @@ describe('Test router dispactControlelr with path parameters', () => {
         let requestMock = TypeMoq.Mock.ofType<Request>();
         let containerMock = TypeMoq.Mock.ofType<Container>();
 
-        requestMock.setup(c => c.getPath()).returns(() => '/test1/' + valParam);
-        requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.POST);
+        requestMock.setup(r => r.getPath()).returns(() => '/test1/' + valParam);
+        requestMock.setup(r => r.getRequestMethod()).returns(() => HttpMethods.POST);
+        requestMock.setup(r => r.getOrFail('val')).returns(() => valParam);
+        requestMock.setup(r => r.add('val', 'abc')).verifiable(TypeMoq.Times.once());
 
         let router = new Router<Middleware, Controller, Route<Middleware, Controller>>(requestMock.object, containerMock.object);
         router.route(routes);
@@ -147,6 +149,7 @@ describe('Test router dispactControlelr with path parameters', () => {
 
         expect(response.statusCode).toBe(200);
         expect(response.body.val).toBe(valParam);
+        requestMock.verifyAll();
     });
 
     test('request object get injected', async () => {
@@ -177,6 +180,8 @@ describe('Test router dispactControlelr with path parameters', () => {
 
         requestMock.setup(c => c.getPath()).returns(() => resource);
         requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.POST);
+        requestMock.setup(r => r.getOrFail('val')).returns(() => valParam);
+        requestMock.setup(r => r.add('val', 'abc')).verifiable(TypeMoq.Times.once());
 
         let router = new Router<Middleware, Controller, Route<Middleware, Controller>>(requestMock.object, containerMock.object);
         router.route(routes);
@@ -188,6 +193,7 @@ describe('Test router dispactControlelr with path parameters', () => {
         expect(response.statusCode).toBe(200);
         expect(response.body.resource).toBe(resource);
         expect(response.body.val).toBe(valParam);
+        requestMock.verifyAll();
     });
 
     test('throw error when cant find argument to inject into function', async () => {
@@ -196,6 +202,8 @@ describe('Test router dispactControlelr with path parameters', () => {
 
         requestMock.setup(c => c.getPath()).returns(() => '/test1');
         requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.POST);
+        requestMock.setup(r => r.getOrFail('val')).returns(() => {throw Error()}).verifiable(TypeMoq.Times.once());
+        requestMock.setup(r => r.add('val', 'abc')).verifiable(TypeMoq.Times.never());
 
         let router = new Router<Middleware, Controller, Route<Middleware, Controller>>(requestMock.object, containerMock.object);
         router.route(routes);
@@ -209,5 +217,6 @@ describe('Test router dispactControlelr with path parameters', () => {
             'Error Message': 'Unable to inject val into TestController.testWithPathParam',
             'Mindless Message': 'Unable to resolve requested controller or method make sure your routes are configured properly'
         });
+        requestMock.verifyAll();
     });
 });


### PR DESCRIPTION
Query, path and body params are now injected into controller methods. Need to take a look at how the API gw handles query params and how we are handling with the route parser and make sure we arnt double processing them. 

closes #37