### PR TITLE
updated request object and table

### DIFF
--- a/lib/data/dynamo/table.ts
+++ b/lib/data/dynamo/table.ts
@@ -77,6 +77,33 @@ export abstract class DynamoTable<TModel extends Model> implements ModelFactory<
                     console.error(`Error getting items on ${this.tableName} table. Err: ${err}`);
                     reject(err);
                 } else if (document === undefined || document === null) {
+                    resolve(undefined);
+                }
+                else {
+                    const model = new this.TConstructor(document.attrs);
+                    resolve(model);
+                }
+            };
+
+            if (rangeKey == null) {
+                this.dynModel.get(hashKey, options, callback);
+            }
+            else {
+                this.dynModel.get(hashKey, rangeKey, options, callback);
+            }
+        };
+
+        return new Promise(promiseCallback);
+    }
+
+    public getOrFail(hashKey: string, options: GetItemOptions = {}, rangeKey?: string): Promise<TModel> {
+
+        let promiseCallback = (resolve, reject) => {
+            let callback = (err, document) => {
+                if (err) {
+                    console.error(`Error getting items on ${this.tableName} table. Err: ${err}`);
+                    reject(err);
+                } else if (document === undefined || document === null) {
                     const keyMsg = `HashKey: ${hashKey} ` + (rangeKey === undefined) ? "": `, RangeKey: ${rangeKey}`;
                     console.error(`No item with ${keyMsg} found on ${this.tableName} table.`);
                     reject("Model not found");

--- a/lib/request/request.ts
+++ b/lib/request/request.ts
@@ -4,6 +4,7 @@ import { IRequest } from './request-interface';
 
 export class Request implements IRequest {
     protected _body: { [key: string]: any };
+    protected data: { [key: string]: any } = {};
     public RouteMetaData: any;
 
     constructor(protected event: Event) {
@@ -23,11 +24,11 @@ export class Request implements IRequest {
         }
     }
 
-    getPath(): string {
+    get path(): string {
         return this.event.path;
     }
 
-    getRequestMethod(): HttpMethods {
+    get method(): HttpMethods {
         return HttpMethods[this.event.httpMethod.toUpperCase()];
     }
 
@@ -42,14 +43,14 @@ export class Request implements IRequest {
 
     get(key: string): any {
 
-        if ('undefined' !== typeof this.event.pathParameters[key]) {
-            return this.event.pathParameters[key];
+        if (typeof this.data[key] !== 'undefined') {
+            return this.data[key];
         }
-        if ('undefined' !== typeof this.event.queryStringParameters[key]) {
-            return this.event.queryStringParameters[key];
-        }
-        if ('undefined' !== typeof this._body[key]) {
+        if (typeof this._body[key] !== 'undefined') {
             return this._body[key];
+        }
+        if (typeof this.event.queryStringParameters[key] !== 'undefined') {
+            return this.event.queryStringParameters[key];
         }
 
         return undefined;
@@ -64,8 +65,8 @@ export class Request implements IRequest {
     }
 
     add(key: string, val: any, overwrite: boolean = false): void {
-        if (overwrite || 'undefined' === typeof this._body[key]) {
-            this._body[key] = val;
+        if (overwrite || 'undefined' === typeof this.data[key]) {
+            this.data[key] = val;
             return;
         }
 

--- a/lib/routing/router.ts
+++ b/lib/routing/router.ts
@@ -33,7 +33,7 @@ export class Router<M extends Middleware, C extends Controller, R extends Route<
 
     // add path params to request object
     Object.keys(this.pathParams).forEach(param => {
-      this.request.add(param, this.pathParams[param]);
+      this.request.add(param, this.pathParams[param],true);
     });
 
     this.addRouteMetaDataToRequest();

--- a/lib/routing/router.ts
+++ b/lib/routing/router.ts
@@ -22,14 +22,14 @@ export class Router<M extends Middleware, C extends Controller, R extends Route<
   ) { }
 
   public route(routes: R[]): void {
-    this.requestPath = this.request.getPath()
-    this.requestMethod = this.request.getRequestMethod();
+    this.requestPath = this.request.path;
+    this.requestMethod = this.request.method;
 
     try {
       this.subjectRoute = this.getRequestRoute(routes);
     } catch (e) {
       throw e; // could not find route, lets just throw for now.
-    };
+    }
 
     // add path params to request object
     Object.keys(this.pathParams).forEach(param => {
@@ -76,7 +76,7 @@ export class Router<M extends Middleware, C extends Controller, R extends Route<
      * there should be no need for them outside of this router
      */
     for (let prop in this.subjectRoute) {
-      if ('undefined' !== typeof this.subjectRoute[prop] && prop != 'controller' && prop != 'middleware') {
+      if ('undefined' !== typeof this.subjectRoute[prop] && prop !== 'controller' && prop !== 'middleware') {
         narrowedRoute[prop] = this.subjectRoute[prop];
       }
     }
@@ -103,8 +103,7 @@ export class Router<M extends Middleware, C extends Controller, R extends Route<
       const params = Router.getParameters(subjectController[this.subjectRoute.function]); // TODO: run all this on construction maybe.
       let args = params.map(this.getArgToInject);
 
-      let response: Response = await subjectController[this.subjectRoute.function](...args);
-      return response;
+      return await subjectController[this.subjectRoute.function](...args);
     } catch (e) {
       let body = {
         'Error Message': e.message,
@@ -121,7 +120,7 @@ export class Router<M extends Middleware, C extends Controller, R extends Route<
     return args.split(",")
       .map(arg => arg.replace(/\/\*.*\*\//, "").trim()) // get rid of inline comments, trim whitespace
       .filter(arg => arg); // dont add undefineds
-  }
+  };
 
   private getArgToInject = (param) => {
     if (param == 'request') {

--- a/tests/request/request.test.ts
+++ b/tests/request/request.test.ts
@@ -26,8 +26,8 @@ describe('Test request constructor', () => {
 
     test('empty event', () => {
         let request = new Request(localEvent);
-        expect(request.getPath()).toBe("");
-        expect(request.getRequestMethod()).toBe(HttpMethods.GET);
+        expect(request.path).toBe("");
+        expect(request.method).toBe(HttpMethods.GET);
     });
 
     test('successfully parses json event body', () => {
@@ -40,7 +40,6 @@ describe('Test request constructor', () => {
         eventWithBody.body = JSON.stringify(body);
 
         let request = new Request(eventWithBody);
-
 
         expect(request.get('name')).toBe("zach");
         expect(request.get('number')).toBe(12345);
@@ -62,10 +61,10 @@ describe('Test request constructor', () => {
 
 describe('Test request get method ', () => {
     const localEvent = getEvent();
-    test('get path parameters', () => {
+    test('get added params', () => {
         let defaultEvent = Object.assign({}, localEvent);
-        defaultEvent.pathParameters['param'] = 'abc';
         let request = new Request(defaultEvent);
+        request.add('param', 'abc');
 
         let actualRetrievedValue = request.get('param');
 

--- a/tests/routing/router.test.ts
+++ b/tests/routing/router.test.ts
@@ -118,7 +118,7 @@ describe('Test router dispactControlelr with path parameters', () => {
         requestMock.setup(r => r.path).returns(() => '/test1/' + valParam);
         requestMock.setup(r => r.method).returns(() => HttpMethods.POST);
         requestMock.setup(r => r.getOrFail('val')).returns(() => valParam);
-        requestMock.setup(r => r.add('val', 'abc')).verifiable(TypeMoq.Times.once());
+        requestMock.setup(r => r.add('val', 'abc', true)).verifiable(TypeMoq.Times.once());
 
         let router = new Router<Middleware, Controller, Route<Middleware, Controller>>(requestMock.object, containerMock.object);
         router.route(routes);
@@ -181,7 +181,7 @@ describe('Test router dispactControlelr with path parameters', () => {
         requestMock.setup(c => c.path).returns(() => resource);
         requestMock.setup(c => c.method).returns(() => HttpMethods.POST);
         requestMock.setup(r => r.getOrFail('val')).returns(() => valParam);
-        requestMock.setup(r => r.add('val', 'abc')).verifiable(TypeMoq.Times.once());
+        requestMock.setup(r => r.add('val', 'abc', true)).verifiable(TypeMoq.Times.once());
 
         let router = new Router<Middleware, Controller, Route<Middleware, Controller>>(requestMock.object, containerMock.object);
         router.route(routes);

--- a/tests/routing/router.test.ts
+++ b/tests/routing/router.test.ts
@@ -247,7 +247,7 @@ describe('Test router dispactControlelr with path parameters', () => {
         requestMock.setup(c => c.path).returns(() => '/test1?val=' + valParam);
         requestMock.setup(c => c.method).returns(() => HttpMethods.POST);
         requestMock.setup(r => r.getOrFail('val')).returns(() => valParam ).verifiable(TypeMoq.Times.once());
-        requestMock.setup(r => r.add('val', 'abc')).verifiable(TypeMoq.Times.once());
+        requestMock.setup(r => r.add('val', 'abc', true)).verifiable(TypeMoq.Times.once());
 
         let router = new Router<Middleware, Controller, Route<Middleware, Controller>>(requestMock.object, containerMock.object);
         router.route(routes);

--- a/tests/routing/router.test.ts
+++ b/tests/routing/router.test.ts
@@ -16,14 +16,14 @@ class TestController extends Controller {
     }
     // Note: Request parameter 
     testWithRequestParam(request: Request) {
-        return new Response(200, { resource: request.getPath() });
+        return new Response(200, { resource: request.path });
     }
     testWithPathParam(val: string): Response {
         return new Response(200, { val: val });
     }
     testWithRequestAndPathParam(request: Request, val: string) {
         const res = {
-            resource: request.getPath(),
+            resource: request.path,
             val: val
         };
         return new Response(200, res);
@@ -45,8 +45,8 @@ describe('Test router route method', () => {
         }
     ];
 
-    requestMock.setup(c => c.getPath()).returns(() => '/test');
-    requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.GET);
+    requestMock.setup(c => c.path).returns(() => '/test');
+    requestMock.setup(c => c.method).returns(() => HttpMethods.GET);
 
     test('Throws error when route group undefined', () => {
         let router = new Router<Middleware, Controller, MindlessRoute>(requestMock.object, containerMock.object);
@@ -69,8 +69,8 @@ describe('Test router dispatchController method', () => {
         }
     ];
 
-    requestMock.setup(c => c.getPath()).returns(() => '/test');
-    requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.POST);
+    requestMock.setup(c => c.path).returns(() => '/test');
+    requestMock.setup(c => c.method).returns(() => HttpMethods.POST);
     let router = new Router<Middleware, Controller, Route<Middleware, Controller>>(requestMock.object, containerMock.object);
     router.route(routes);
 
@@ -98,8 +98,6 @@ describe('Test router dispatchController method', () => {
 
 describe('Test router dispactControlelr with path parameters', () => {
 
-
-
     test('path parameter get injected', async () => {
 
         const routes: MindlessRoute[] = [
@@ -117,8 +115,8 @@ describe('Test router dispactControlelr with path parameters', () => {
         let requestMock = TypeMoq.Mock.ofType<Request>();
         let containerMock = TypeMoq.Mock.ofType<Container>();
 
-        requestMock.setup(r => r.getPath()).returns(() => '/test1/' + valParam);
-        requestMock.setup(r => r.getRequestMethod()).returns(() => HttpMethods.POST);
+        requestMock.setup(r => r.path).returns(() => '/test1/' + valParam);
+        requestMock.setup(r => r.method).returns(() => HttpMethods.POST);
         requestMock.setup(r => r.getOrFail('val')).returns(() => valParam);
         requestMock.setup(r => r.add('val', 'abc')).verifiable(TypeMoq.Times.once());
 
@@ -151,8 +149,8 @@ describe('Test router dispactControlelr with path parameters', () => {
         let requestMock = TypeMoq.Mock.ofType<Request>();
         let containerMock = TypeMoq.Mock.ofType<Container>();
 
-        requestMock.setup(c => c.getPath()).returns(() => resource);
-        requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.POST);
+        requestMock.setup(c => c.path).returns(() => resource);
+        requestMock.setup(c => c.method).returns(() => HttpMethods.POST);
 
         let router = new Router<Middleware, Controller, Route<Middleware, Controller>>(requestMock.object, containerMock.object);
         router.route(routes);
@@ -180,8 +178,8 @@ describe('Test router dispactControlelr with path parameters', () => {
         let requestMock = TypeMoq.Mock.ofType<Request>();
         let containerMock = TypeMoq.Mock.ofType<Container>();
 
-        requestMock.setup(c => c.getPath()).returns(() => resource);
-        requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.POST);
+        requestMock.setup(c => c.path).returns(() => resource);
+        requestMock.setup(c => c.method).returns(() => HttpMethods.POST);
         requestMock.setup(r => r.getOrFail('val')).returns(() => valParam);
         requestMock.setup(r => r.add('val', 'abc')).verifiable(TypeMoq.Times.once());
 
@@ -212,8 +210,8 @@ describe('Test router dispactControlelr with path parameters', () => {
         let requestMock = TypeMoq.Mock.ofType<Request>();
         let containerMock = TypeMoq.Mock.ofType<Container>();
 
-        requestMock.setup(c => c.getPath()).returns(() => '/test1');
-        requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.POST);
+        requestMock.setup(c => c.path).returns(() => '/test1');
+        requestMock.setup(c => c.method).returns(() => HttpMethods.POST);
         requestMock.setup(r => r.getOrFail('val')).returns(() => { throw Error() }).verifiable(TypeMoq.Times.once());
         requestMock.setup(r => r.add('val', 'abc')).verifiable(TypeMoq.Times.never());
 
@@ -246,8 +244,8 @@ describe('Test router dispactControlelr with path parameters', () => {
         let requestMock = TypeMoq.Mock.ofType<Request>();
         let containerMock = TypeMoq.Mock.ofType<Container>();
 
-        requestMock.setup(c => c.getPath()).returns(() => '/test1?val=' + valParam);
-        requestMock.setup(c => c.getRequestMethod()).returns(() => HttpMethods.POST);
+        requestMock.setup(c => c.path).returns(() => '/test1?val=' + valParam);
+        requestMock.setup(c => c.method).returns(() => HttpMethods.POST);
         requestMock.setup(r => r.getOrFail('val')).returns(() => valParam ).verifiable(TypeMoq.Times.once());
         requestMock.setup(r => r.add('val', 'abc')).verifiable(TypeMoq.Times.once());
 


### PR DESCRIPTION
closes #54 and closes #55 
This removes `getPath` and `getRequestMethod` from the `Request` object. Instead you should now use the `path` and `method` getters.