### PR TITLE
Allow keys with null values to be retrieved by getOrFail()

### DIFF
--- a/src/request/request.ts
+++ b/src/request/request.ts
@@ -34,7 +34,7 @@ export class Request implements IRequest {
 
   public getOrFail(key: string): any {
     const value = this.get(key)
-    if (value) {
+    if (value !== undefined) {
       return value
     }
 

--- a/test/request/request.test.ts
+++ b/test/request/request.test.ts
@@ -82,6 +82,17 @@ describe('Test request get method ', () => {
     expect(actualRetrievedValue).toBe('abc')
   })
 
+  test('get null query string parameters', () => {
+    let defaultEvent = getEvent()
+    defaultEvent.queryStringParameters['param'] = null
+
+    let request = new Request(defaultEvent)
+
+    let actualRetrievedValue = request.get('param')
+
+    expect(actualRetrievedValue).toBe(null)
+  })
+
   test('get body parameters', () => {
     let defaultEvent = getEvent()
 
@@ -94,6 +105,18 @@ describe('Test request get method ', () => {
     expect(actualRetrievedValue).toBe('abc')
   })
 
+  test('get null body parameters', () => {
+    let defaultEvent = getEvent()
+
+    defaultEvent.body = JSON.stringify({ param: null })
+
+    let request = new Request(defaultEvent)
+
+    let actualRetrievedValue = request.get('param')
+
+    expect(actualRetrievedValue).toBe(null)
+  })
+
   test('getOrFail retrieve body parameters', () => {
     let defaultEvent = getEvent()
 
@@ -104,6 +127,18 @@ describe('Test request get method ', () => {
     let actualRetrievedValue = request.getOrFail('param')
 
     expect(actualRetrievedValue).toBe('abc')
+  })
+
+  test('getOrFail retrieve null body parameters', () => {
+    let defaultEvent = getEvent()
+
+    defaultEvent.body = JSON.stringify({ param: null })
+
+    let request = new Request(defaultEvent)
+
+    let actualRetrievedValue = request.getOrFail('param')
+
+    expect(actualRetrievedValue).toBe(null)
   })
 
   test('invalid key getOrFail', () => {
@@ -142,7 +177,7 @@ describe('Test request header', () => {
       request.headerOrFail('abc')
     }).toThrow(/key not found/)
   })
-  
+
   test('headerOrFail retrieve header', () => {
     let event = getEvent()
     event.headers['test'] = 'val'
@@ -150,16 +185,20 @@ describe('Test request header', () => {
     expect(request.headerOrFail('test')).toBe('val')
   })
 
-  
+  test('headerOrFail retrieve null header', () => {
+    let event = getEvent()
+    event.headers['test'] = null
+    let request = new Request(event)
+    expect(request.headerOrFail('test')).toBe(null)
+  })
+
   test('undefined header value', () => {
     let event = getEvent()
     let request = new Request(event)
-    
-    expect(() => {
-      request.header('abc').toBeUndefined()
-    }     
+
+    expect(request.header('abc')).toBeUndefined()
   })
-  
+
   test('retrieve header value', () => {
     let event = getEvent()
     event.headers['test'] = 'val'
@@ -168,7 +207,6 @@ describe('Test request header', () => {
 
     expect(request.header('test')).toBe('val')
   })
-  
 })
 
 describe('Test request add method', () => {


### PR DESCRIPTION
Previously, keys (that were present) with null values would not be picked up and instead the error was getting thrown. If this is by design, feel free to close this PR.